### PR TITLE
Added extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,10 @@
   "require": {
     "php": "^7.",
     "typo3/cms-core": "^9.5 || ^10.2"
+  },
+  "extra": {
+		"typo3/cms": {
+			"extension-key": "save_close_ce"
+    }
   }
 }


### PR DESCRIPTION
```TYPO3 Extension Package "goran/save_close_ce", does not define extension key in composer.json.
Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)```